### PR TITLE
fix: make dataset searchparam optional, update by-id validation schemas

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -129,7 +129,7 @@ export namespace SearchEntities {
     /**
      * Limit query to source datasets.
      */
-    datasets: Array<Dataset['id']>
+    datasets?: Array<Dataset['id']>
   }>
   export type Params = SearchParams
   export type Response = PaginatedResponse<Entity>
@@ -281,7 +281,7 @@ export namespace BirthStatisticsSearch {
     /**
      * Limit query to source datasets.
      */
-    datasets: Array<Dataset['id']>
+    datasets?: Array<Dataset['id']>
     /**
      * Into how many bins the result set should be chunked.
      *
@@ -370,7 +370,7 @@ export namespace DeathStatisticsSearch {
     /**
      * Limit query to source datasets.
      */
-    datasets: Array<Dataset['id']>
+    datasets?: Array<Dataset['id']>
     /**
      * Into how many bins the result set should be chunked.
      *
@@ -459,7 +459,7 @@ export namespace OccupationStatisticsSearch {
     /**
      * Limit query to source datasets.
      */
-    datasets: Array<Dataset['id']>
+    datasets?: Array<Dataset['id']>
   }
   export type Params = SearchParams
   export type Response = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+// @internal
 export let baseUrl: URL | string | null = null
 
 export function configureApiBaseUrl(url: URL | string): void {

--- a/src/validation-schemas.ts
+++ b/src/validation-schemas.ts
@@ -222,17 +222,19 @@ const paginatedRequest = z.object({
 
 //
 
-export const getEntitiesByIdSearchParams = paginatedRequest.merge(
-  z.object({
-    ids: z.array(entityBase.shape.id),
-  }),
-)
+export const getEntityByIdPathParams = z.object({
+  id: entityBase.shape.id,
+})
 
-export const getEntitiesByIdResponse = paginatedResponse.merge(
-  z.object({
-    results: z.array(entity),
-  }),
-)
+export const getEntityByIdResponse = entity
+
+//
+
+export const getEntityEventByIdPathParams = z.object({
+  id: entityEvent.shape.id,
+})
+
+export const getEntityEventByIdResponse = entityEvent
 
 //
 


### PR DESCRIPTION
- make `dataset` search param optional
- update validation schemas for entity/event by id endpoints
- make base url as internal