### PR TITLE
fix: remove place property from event

### DIFF
--- a/.changeset/rich-planes-laugh.md
+++ b/.changeset/rich-planes-laugh.md
@@ -1,0 +1,5 @@
+---
+"@intavia/api-client": patch
+---
+
+remove place property from entity-event

--- a/src/models.ts
+++ b/src/models.ts
@@ -88,7 +88,6 @@ export interface EntityEvent {
 	source?: Source;
 	startDate?: IsoDateString;
 	endDate?: IsoDateString;
-	place?: Place["id"];
 	relations: Array<EntityEventRelation>;
 }
 

--- a/src/validation-schemas.ts
+++ b/src/validation-schemas.ts
@@ -155,8 +155,8 @@ export const entityEventRelation = z.object({
 	id: z.string(),
 	label: internationalizedLabel,
 	description: z.string().optional(),
-	entity,
-	role: entityRelationRole.optional(),
+	entity: z.string() /** entity.shape.id */,
+	role: entityRelationRole.shape.id.optional(),
 	source: source.optional(),
 });
 
@@ -164,11 +164,10 @@ export const entityEvent = z.object({
 	id: z.string(),
 	label: internationalizedLabel,
 	description: z.string().optional(),
-	kind: entityEventKind.optional(),
+	kind: entityEventKind.shape.id.optional(),
 	source: source.optional(),
 	startDate: isoDateString.optional(),
 	endDate: isoDateString.optional(),
-	place: place.optional(),
 	relations: z.array(entityEventRelation).optional(),
 });
 


### PR DESCRIPTION
closes #6

remove `place` property from `EntityEvent` - place is moved to a relation with role "took place at".

also fixes validation schemas for `event.kind` and `relation.role`, which now reference `id` only.